### PR TITLE
Fix Some Swagger UI functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ This project is a Bottle plugin for working with Swagger.
 `Bottle <http://bottlepy.org/>`_ is a Python web framework.
 `Swagger (OpenAPI) <http://swagger.io/>`_ is a standard for defining REST APIs.
 
-This plugin is derived from Charles Blaxland's bottle-swagger work:
+This plugin is derived from Charles Blaxland's bottle-swagger plugin:
 https://github.com/ampedandwired/bottle-swagger
 
 So if you are serving a REST API with Bottle,
@@ -91,6 +91,8 @@ There are a number of arguments that you can pass to the plugin constructor:
 * ``serve_swagger_ui`` - Boolean (default ``False``) Should we use a built-in copy of Swagger UI to serve up docs for this API?
 
 * ``swagger_ui_suburl`` - String (default ``"/ui/"``) The API suburl to serve the built-in Swagger UI up at, if turned on.
+
+* ``swagger_ui_validator_url`` -- String (default ``None``) The URL for a Swagger spec validator. By default this is None (i.e. off).
 
 * ``extra_bravado_config`` - Dict (default ``None``) Any additional configuration items to pass to Bravado core.
 

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ There are a number of arguments that you can pass to the plugin constructor:
 
 * ``swagger_base_path`` - String (default ``None``) Used to set and override the ``basePath`` mechanic for telling bottle what subpath to serve the API from.
 
+* ``adjust_api_base_path`` - Boolean (default ``True``) Adjust the basePath reported by the swagger.json. This is important if your WSGI application is running under a subpath.
+
 * ``serve_swagger_schema`` - Boolean (default ``True``) indicating if the Swagger schema JSON should be served
 
 * ``swagger_schema_suburl`` - URL (default ``"/swagger.json"``) on which to serve the Swagger schema JSON from the API subpath

--- a/bottle_swagger/__init__.py
+++ b/bottle_swagger/__init__.py
@@ -18,15 +18,11 @@ with open(SWAGGER_UI_INDEX_TEMPLATE_PATH, 'r') as f:
     SWAGGER_UI_INDEX_TEMPLATE = f.read()
 
 
-def render_index_html(swagger_spec_url):
-    return SimpleTemplate(SWAGGER_UI_INDEX_TEMPLATE).render(swagger_spec_url=swagger_spec_url)
-
-
-try:
-    from bottle_swagger import SWAGGER_UI_DIR, render_index_html
-    SWAGGER_UI_IMPORT_SUCCESS = True
-except ImportError:
-    SWAGGER_UI_IMPORT_SUCCESS = False
+def render_index_html(swagger_spec_url, validator_url=None):
+    return SimpleTemplate(SWAGGER_UI_INDEX_TEMPLATE).render(
+        swagger_spec_url=swagger_spec_url,
+        validator_url=json_dumps(validator_url)
+    )
 
 
 def _error_response(status, e):
@@ -133,6 +129,7 @@ class SwaggerPlugin(object):
     * ``swagger_schema_suburl`` -- (str) The subpath in the API to serve the swagger schema.
     * ``serve_swagger_ui`` -- (bool) Should we also serve a copy of Swagger UI?
     * ``swagger_ui_suburl`` -- (str) The subpath from the API to serve the integrate Swagger UI up at.
+    * ``swagger_ui_validator_url`` -- (str) The URL for a Swagger spec validator. By default this is None (i.e. off).
     * ``extra_bravado_config`` -- (object) Any additional Bravado configuration items you may want.
     """
     DEFAULT_SWAGGER_SCHEMA_SUBURL = '/swagger.json'
@@ -161,6 +158,7 @@ class SwaggerPlugin(object):
                  swagger_schema_suburl=DEFAULT_SWAGGER_SCHEMA_SUBURL,
                  serve_swagger_ui=False,
                  swagger_ui_suburl=DEFAULT_SWAGGER_UI_SUBURL,
+                 swagger_ui_validator_url=None,
                  extra_bravado_config=None):
         """
         Add Swagger validation to your Bottle application.
@@ -209,6 +207,8 @@ class SwaggerPlugin(object):
         :type serve_swagger_ui: bool
         :param swagger_ui_suburl: The subpath from the API to serve the integrate Swagger UI up at.
         :type swagger_ui_suburl: str
+        :param swagger_ui_validator_url: The URL for a Swagger validator instance. If None, validation in the UI is off.
+        :type swagger_ui_validator_url: str | NoneType
         :param extra_bravado_config: Any additional Bravado configuration items you may want.
         :type extra_bravado_config: object
         """
@@ -225,9 +225,6 @@ class SwaggerPlugin(object):
         self.exception_handler = exception_handler
         self.serve_swagger_schema = serve_swagger_schema or self.serve_swagger_ui
         self.serve_swagger_ui = serve_swagger_ui
-
-        if self.serve_swagger_ui and not SWAGGER_UI_IMPORT_SUCCESS:
-            raise ImportError("Unable to load built-in Swagger UI!")
 
         self.swagger_schema_suburl = swagger_schema_suburl
         self.swagger_ui_suburl = swagger_ui_suburl

--- a/bottle_swagger/__init__.py
+++ b/bottle_swagger/__init__.py
@@ -225,6 +225,7 @@ class SwaggerPlugin(object):
         self.exception_handler = exception_handler
         self.serve_swagger_schema = serve_swagger_schema or self.serve_swagger_ui
         self.serve_swagger_ui = serve_swagger_ui
+        self.swagger_ui_validator_url = swagger_ui_validator_url
 
         self.swagger_schema_suburl = swagger_schema_suburl
         self.swagger_ui_suburl = swagger_ui_suburl
@@ -261,7 +262,7 @@ class SwaggerPlugin(object):
         if self.serve_swagger_ui:
             @app.get(swagger_ui_base_url)
             def swagger_ui_index():
-                return render_index_html(app.get_url(swagger_schema_url))
+                return render_index_html(app.get_url(swagger_schema_url), validator_url=self.swagger_ui_validator_url)
 
             @app.get(urljoin(swagger_ui_base_url, "<path:path>"))
             def swagger_ui_assets(path):

--- a/bottle_swagger/vendor/swagger-ui-3.22.2-dist/index.html.st
+++ b/bottle_swagger/vendor/swagger-ui-3.22.2-dist/index.html.st
@@ -49,7 +49,8 @@
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout"
+        layout: "StandaloneLayout",
+        validatorUrl: {{! validator_url }}
       });
       // End Swagger UI call region
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, Robert Cope, Charles Blaxland'
 author = 'Robert Cope, Charles Blaxland'
 
 # The full version, including alpha/beta/rc tags
-release = '2.0.1'
+release = '2.0.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def _read(fname):
 
 
 REQUIREMENTS = [l for l in _read('requirements.txt').split('\n') if l and not l.startswith('#')]
-VERSION = '2.0.2'
+VERSION = '2.0.3'
 
 setup(
         name='bottle-swagger-2',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def _read(fname):
 
 
 REQUIREMENTS = [l for l in _read('requirements.txt').split('\n') if l and not l.startswith('#')]
-VERSION = '2.0.1'
+VERSION = '2.0.2'
 
 setup(
         name='bottle-swagger-2',
@@ -19,9 +19,7 @@ setup(
         url='https://github.com/cope-systems/bottle-swagger',
         download_url='https://github.com/cope-systems/bottle-swaggerr/archive/v{}.tar.gz'.format(VERSION),
         description='Swagger Integration for Bottle',
-        long_description="""
-        bottle-swagger-2 is a revamped Swagger 2.0/Bravado integration for the Bottle web framework.
-        """.strip(),
+        long_description=_read("README.rst"),
         author='Robert Cope, Charles Blaxland',
         author_email='robert@copesystems.com, charles.blaxland@gmail.com',
         license='MIT',


### PR DESCRIPTION
- Swagger validator for Swagger UI is off by default, and can now be configured as to what URL it points to.
- Swagger.json now by default reports the correct adjusted basePath when the Bottle application is run in a subpath.