### PR TITLE
Fix a problem where access to attribute was done before being defined.

### DIFF
--- a/bottle_swagger/__init__.py
+++ b/bottle_swagger/__init__.py
@@ -230,8 +230,8 @@ class SwaggerPlugin(object):
         self.invalid_response_handler = invalid_response_handler
         self.swagger_op_not_found_handler = swagger_op_not_found_handler
         self.exception_handler = exception_handler
-        self.serve_swagger_schema = serve_swagger_schema or self.serve_swagger_ui
         self.serve_swagger_ui = serve_swagger_ui
+        self.serve_swagger_schema = serve_swagger_schema or serve_swagger_ui
         self.swagger_ui_validator_url = swagger_ui_validator_url
 
         self.swagger_schema_suburl = swagger_schema_suburl

--- a/test/test_bottle_swagger.py
+++ b/test/test_bottle_swagger.py
@@ -296,6 +296,18 @@ class TestBottleSwagger(TestCase):
         )
         self.assertEqual(response.status_int, 200)
 
+    def test_dont_serve_schema(self):
+        bottle_app = Bottle()
+        bottle_app.install(self._make_swagger_plugin(
+            serve_swagger_ui=False, serve_swagger_schema=False, ignore_undefined_api_routes=True
+        ))
+        @bottle_app.route("/", "GET")
+        def index():
+            return "test"
+        test_app = TestApp(bottle_app)
+        response = test_app.get("/")
+        self.assertEqual(response.status_int, 200)
+
     def _test_request(self, swagger_plugin=None, method='GET', url='/thing', route_url=None, request_json=VALID_JSON,
                       response_json=VALID_JSON, headers=None, content_type='application/json',
                       extra_check=lambda *args, **kwargs: True):


### PR DESCRIPTION
Github Issue #8
    
Fixed an issue where the serve_swagger_ui attribute of the plugin was
referenced before being defined if the user set serve_swagger_schema
to false.


Should solve #8 