### PR TITLE
Github Issue #9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,11 @@ There are a number of arguments that you can pass to the plugin constructor:
 
 * ``serve_swagger_ui`` - Boolean (default ``False``) Should we use a built-in copy of Swagger UI to serve up docs for this API?
 
+* ``swagger_ui_schema_url`` - String or Arity 0 callable returning a string (default ``None``) If this is not none and the Swagger UI is turned on, this will be used to set the Swagger schema URL from which the UI draws the schema by default. If this is an arity 0 callable (i.e. a function with no arguments), this will be evaluated every time the UI is generated, which may allow the developer to dynamically select the schema URL.
+
 * ``swagger_ui_suburl`` - String (default ``"/ui/"``) The API suburl to serve the built-in Swagger UI up at, if turned on.
 
-* ``swagger_ui_validator_url`` -- String (default ``None``) The URL for a Swagger spec validator. By default this is None (i.e. off).
+* ``swagger_ui_validator_url`` -- String (default ``None``) The URL for a Swagger spec validator. By default this is None (i.e. off). This may also be an arity 0 callable that will dynamically select the validator URL when the UI is generated.
 
 * ``extra_bravado_config`` - Dict (default ``None``) Any additional configuration items to pass to Bravado core.
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def _read(fname):
 
 
 REQUIREMENTS = [l for l in _read('requirements.txt').split('\n') if l and not l.startswith('#')]
-VERSION = '2.0.6'
+VERSION = '2.0.7'
 
 setup(
         name='bottle-swagger-2',


### PR DESCRIPTION
Added a way to manually override the Swagger UI schema URL, if so
desired. Added tests to verify the new behavior, and some additional
documentation about how to use this.

@ereboschi, please let me know if this is enough to handle your use case requested in #9 